### PR TITLE
Allow docker containers to be tagged but not pushed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ COMPOSE_FILE?=docker-compose.yml
 
 # This target (the first target in the build file) is the one that is executed if no 
 # command line args are specified.
-release: clean utest build push
+default: clean utest build tag
 
 # builds a docker image that builds the app and packages it into a minimal docker image
 build:
@@ -21,6 +21,9 @@ build:
 # push the image to an registry
 push:
 	cd scripts; bash push.sh ${VERSION} ${IMAGE}:${VERSION}
+
+tag:
+	cd scripts; bash tag.sh ${VERSION} ${IMAGE}:${VERSION}
 
 uselocal:
 	cd scripts; bash use-local-repos.sh

--- a/scripts/tag.sh
+++ b/scripts/tag.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+echo "****************************************"
+echo "*** Tag docker image with the branch name  ***"
+echo "****************************************"
+
+# Docker image name on docker hub
+IMAGE_NAME=consensys/fc-retrieval-itest
+
+VERSION=$1
+echo "Itest version: $VERSION"
+IMAGE=$2
+echo "v image: $IMAGE"
+
+
+ITEST_BRANCH=`git rev-parse --abbrev-ref HEAD`
+echo "Repo branch: $ITEST_BRANCH"
+
+TAG="develop-$ITEST_BRANCH"
+echo "TAG: $TAG"
+
+docker tag $IMAGE $IMAGE_NAME:$TAG


### PR DESCRIPTION
Small update that adds in the tag script that was missed from the itest repo + adds in the changes to the makefile to allow usage of this script